### PR TITLE
Update match logic to work with namespace tuples.

### DIFF
--- a/draft-ietf-moq-c4m.md
+++ b/draft-ietf-moq-c4m.md
@@ -53,8 +53,8 @@ author:
 
 
 normative:
-Composite: I-D.draft-lemmons-cose-composite-claims-01
-MoQTransport: I-D.draft-ietf-moq-transport-14
+  Composite: I-D.draft-lemmons-cose-composite-claims-01
+  MoQTransport: I-D.draft-ietf-moq-transport-14
   EDN: I-D.draft-ietf-cbor-edn-literals
   BASE64: RFC4648
   CAT:


### PR DESCRIPTION
The previous logic didn't correctly handle namespace tuples. This now properly treats each tuple as independent, and also has an easy "default" exact matching form. There are some minor example updates throughout to make everything match the new form.